### PR TITLE
Technical 500 response method signature change fix

### DIFF
--- a/debug_error_logging/__init__.py
+++ b/debug_error_logging/__init__.py
@@ -4,7 +4,7 @@
 
 from django.conf import settings
 
-__version__ = '2.0.0'
+__version__ = '2.1.0'
 
 
 def enable_error_logging_in_debug_mode():

--- a/debug_error_logging/__init__.py
+++ b/debug_error_logging/__init__.py
@@ -18,7 +18,7 @@ def enable_error_logging_in_debug_mode():
 
         orig_technical_500_response = debug.technical_500_response
 
-        def custom_technical_500_response(request, exc_type, exc_value, tb, status_code):
+        def custom_technical_500_response(request, exc_type, exc_value, tb, status_code=None):
             """
             Create a technical server error response. The last three arguments are
             the values returned from sys.exc_info() and friends.
@@ -28,6 +28,6 @@ def enable_error_logging_in_debug_mode():
                 exc_info=(exc_type, exc_value, tb),
                 extra={'status_code': 500, 'request': request}
             )
-            return orig_technical_500_response(request, exc_type, exc_value, tb, status_code)
+            return orig_technical_500_response(request, exc_type, exc_value, tb, status_code=status_code)
 
         debug.technical_500_response = custom_technical_500_response


### PR DESCRIPTION
Made custom_technical_500_response 'status_code' a keyword parameter to match the real method it is overriding.
Fixes an error when showing (some) debug logging