### PR TITLE
Python 3 Support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 from setuptools import setup
 import re
@@ -53,9 +54,9 @@ def get_package_data(package):
 if sys.argv[-1] == 'publish':
     os.system("python setup.py sdist upload")
     args = {'version': get_version(package)}
-    print "You probably want to also tag the version now:"
-    print "  git tag -a %(version)s -m 'version %(version)s'" % args
-    print "  git push --tags"
+    print("You probably want to also tag the version now:")
+    print("  git tag -a %(version)s -m 'version %(version)s'" % args)
+    print("  git push --tags")
     sys.exit()
 
 

--- a/testsettings.py
+++ b/testsettings.py
@@ -8,3 +8,5 @@ DATABASES = {
 INSTALLED_APPS = (
     'debug_error_logging',
 )
+
+SECRET_KEY = 'AQzCeWg8k/3j+rgkE0AYrEa5cik2rK9KmjlxdJUS2Wb7NWmWtR'

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=
     py27-django13,
     py26-django14,
     py27-django14,
+    py3-django111,
 
 [testenv]
 commands=
@@ -30,3 +31,8 @@ deps=
 basepython=python2.7
 deps=
     django==1.4
+
+[testenv:py3-django111]
+basepython=python3
+deps=
+    django==1.11


### PR DESCRIPTION
- use print function
- add python 3 to tox tests
- django 1.11 requires secret key to be set (added to test settings)